### PR TITLE
Fix broken multimedia for version 23.7.1.1215

### DIFF
--- a/ru.yandex.Browser.metainfo.xml
+++ b/ru.yandex.Browser.metainfo.xml
@@ -27,6 +27,7 @@
     <release version="23.3.3.706" date="2023-04-27"/>
     <release version="23.3.1.912" date="2023-04-13"/>
     <release version="23.1.5.751" date="2023-03-16"/>
+    <release version="23.1.5.751-1" date="2023-03-26"/>
   </releases>
   <url type="homepage">https://browser.yandex.ru</url>
   <url type="bugtracker">https://browser.yandex.ru/feedback/</url>

--- a/ru.yandex.Browser.metainfo.xml
+++ b/ru.yandex.Browser.metainfo.xml
@@ -17,6 +17,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="23.7.1.1215-1" date="2023-08-26"/>
     <release version="23.7.1.1215" date="2023-08-01"/>
     <release version="23.5.4.685" date="2023-07-05"/>
     <release version="23.5.1.800" date="2023-06-22"/>
@@ -27,7 +28,6 @@
     <release version="23.3.3.706" date="2023-04-27"/>
     <release version="23.3.1.912" date="2023-04-13"/>
     <release version="23.1.5.751" date="2023-03-16"/>
-    <release version="23.1.5.751-1" date="2023-03-26"/>
   </releases>
   <url type="homepage">https://browser.yandex.ru</url>
   <url type="bugtracker">https://browser.yandex.ru/feedback/</url>

--- a/ru.yandex.Browser.yaml
+++ b/ru.yandex.Browser.yaml
@@ -117,7 +117,7 @@ modules:
           root: https://repo.yandex.ru/yandex-browser/rpm/stable/x86_64
           is-main-source: true
       - type: file
-        url: https://ppa.launchpadcontent.net/savoury1/chromium/ubuntu/pool/main/c/chromium-browser/chromium-codecs-ffmpeg-extra_116.0.5845.110-0ubuntu0.22.04.1sav0_amd64.deb"
+        url: https://ppa.launchpadcontent.net/savoury1/chromium/ubuntu/pool/main/c/chromium-browser/chromium-codecs-ffmpeg-extra_116.0.5845.110-0ubuntu0.22.04.1sav0_amd64.deb
         sha256: 310cccc4676dc7107f842e96a8be9d8633b74ad0bb92ad044f27904462d0414c 
         dest-filename: chromium-codecs-ffmpeg-extra.deb
         only-arches: [x86_64]

--- a/ru.yandex.Browser.yaml
+++ b/ru.yandex.Browser.yaml
@@ -117,8 +117,8 @@ modules:
           root: https://repo.yandex.ru/yandex-browser/rpm/stable/x86_64
           is-main-source: true
       - type: file
-        url: https://launchpadlibrarian.net/637033261/chromium-codecs-ffmpeg-extra_108.0.5359.71-0ubuntu0.18.04.5_amd64.deb
-        sha256: 9cde2bbef1c5dff70621b1afb24676201ad824d6be9398796975db48782fab1e
+        url: https://ppa.launchpadcontent.net/savoury1/chromium/ubuntu/pool/main/c/chromium-browser/chromium-codecs-ffmpeg-extra_116.0.5845.110-0ubuntu0.22.04.1sav0_amd64.deb"
+        sha256: 310cccc4676dc7107f842e96a8be9d8633b74ad0bb92ad044f27904462d0414c 
         dest-filename: chromium-codecs-ffmpeg-extra.deb
         only-arches: [x86_64]
       - type: file

--- a/ru.yandex.Browser.yaml
+++ b/ru.yandex.Browser.yaml
@@ -89,11 +89,12 @@ modules:
     build-commands:
       - mkdir -p /app/yandex_browser /app/tmp-install/data /app/tmp-codecs-install/data
       - bsdtar -xf yandex-browser.rpm -C /app/tmp-install
-      - tar -xf opera-codecs.tar.zst -C /app/tmp-codecs-install
+      - ar -x chromium-codecs-ffmpeg-extra.deb --output /app/tmp-codecs-install
+      - tar -xf /app/tmp-codecs-install/data.tar.xz -C /app/tmp-codecs-install/data
       - mv /app/tmp-install/opt/yandex/browser/* /app/yandex_browser
       - install -D /app/tmp-install/usr/share/applications/yandex-browser.desktop
         /app/share/applications/ru.yandex.Browser.desktop
-      - install -D -m755 /app/tmp-codecs-install/usr/lib/opera/lib_extra/libffmpeg.so
+      - install -D -m755 /app/tmp-codecs-install/data/usr/lib/chromium-browser/libffmpeg.so
         /app/yandex_browser
       - rm -rf /app/tmp-install /app/tmp-codecs-install yandex-browser.rpm chromium-codecs-ffmpeg-extra.deb
       - install -D ru.yandex.Browser.svg /app/share/icons/hicolor/scalable/apps/ru.yandex.Browser.svg
@@ -116,9 +117,9 @@ modules:
           root: https://repo.yandex.ru/yandex-browser/rpm/stable/x86_64
           is-main-source: true
       - type: file
-        url: https://archlinux.org/packages/extra/x86_64/opera-ffmpeg-codecs/download/
-        sha256: d4f9ede15ac2deee85033a72afce96c6e21b45c444f25588a80758bb4ee353a3
-        dest-filename: opera-codecs.tar.zst
+        url: https://launchpadlibrarian.net/637033261/chromium-codecs-ffmpeg-extra_108.0.5359.71-0ubuntu0.18.04.5_amd64.deb
+        sha256: 9cde2bbef1c5dff70621b1afb24676201ad824d6be9398796975db48782fab1e
+        dest-filename: chromium-codecs-ffmpeg-extra.deb
         only-arches: [x86_64]
       - type: file
         path: cobalt.ini

--- a/ru.yandex.Browser.yaml
+++ b/ru.yandex.Browser.yaml
@@ -89,12 +89,11 @@ modules:
     build-commands:
       - mkdir -p /app/yandex_browser /app/tmp-install/data /app/tmp-codecs-install/data
       - bsdtar -xf yandex-browser.rpm -C /app/tmp-install
-      - ar -x chromium-codecs-ffmpeg-extra.deb --output /app/tmp-codecs-install
-      - tar -xf /app/tmp-codecs-install/data.tar.xz -C /app/tmp-codecs-install/data
+      - tar -xf opera-codecs.tar.zst -C /app/tmp-codecs-install
       - mv /app/tmp-install/opt/yandex/browser/* /app/yandex_browser
       - install -D /app/tmp-install/usr/share/applications/yandex-browser.desktop
         /app/share/applications/ru.yandex.Browser.desktop
-      - install -D -m755 /app/tmp-codecs-install/data/usr/lib/chromium-browser/libffmpeg.so
+      - install -D -m755 /app/tmp-codecs-install/usr/lib/opera/lib_extra/libffmpeg.so
         /app/yandex_browser
       - rm -rf /app/tmp-install /app/tmp-codecs-install yandex-browser.rpm chromium-codecs-ffmpeg-extra.deb
       - install -D ru.yandex.Browser.svg /app/share/icons/hicolor/scalable/apps/ru.yandex.Browser.svg
@@ -117,9 +116,9 @@ modules:
           root: https://repo.yandex.ru/yandex-browser/rpm/stable/x86_64
           is-main-source: true
       - type: file
-        url: https://launchpadlibrarian.net/637033261/chromium-codecs-ffmpeg-extra_108.0.5359.71-0ubuntu0.18.04.5_amd64.deb
-        sha256: 9cde2bbef1c5dff70621b1afb24676201ad824d6be9398796975db48782fab1e
-        dest-filename: chromium-codecs-ffmpeg-extra.deb
+        url: https://archlinux.org/packages/extra/x86_64/opera-ffmpeg-codecs/download/
+        sha256: d4f9ede15ac2deee85033a72afce96c6e21b45c444f25588a80758bb4ee353a3
+        dest-filename: opera-codecs.tar.zst
         only-arches: [x86_64]
       - type: file
         path: cobalt.ini


### PR DESCRIPTION
Yandex is going to use system-wide GStreamer, but this doesn't work for me yet, so I bundled codecs for new Chromium version instead. 

Fixes #17 .